### PR TITLE
Catch errors accessing localStorage

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,10 +21,11 @@ function env(environment) {
       env.merge(environment, env.parse(window.name));
     }
 
-    if (window.localStorage) {
-      try { env.merge(environment, env.parse(window.localStorage.env || window.localStorage.debug)); }
-      catch (e) {}
-    }
+    try { 
+      if (window.localStorage) {
+        env.merge(environment, env.parse(window.localStorage.env || window.localStorage.debug)); 
+      }
+    } catch (e) {}
 
     if (
          'object' === typeof window.location


### PR DESCRIPTION
It's actually possible that reading `window.localStorage` fails in some circumstances. Notably in Electron preload script (page is not loaded yet and localStorage is bound to the page origin and does not exist on about://blank), where it fails with `Failed to read the 'localStorage' property from 'Window': Access is denied for this document`. 

Just moving the try/catch block up to catch this.